### PR TITLE
Add documentation

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,66 @@
+---
+Order: 30
+Title: Examples
+Description: Examples for using the Cake.Issues.DupFinder addin.
+---
+The following example will call [JetBrains dupFinder] and output the number of warnings.
+
+To call [JetBrains dupFinder] from a Cake script you need to add the `JetBrains.ReSharper.CommandLineTools`:
+
+```csharp
+#tool "nuget:?package=JetBrains.ReSharper.CommandLineTools"
+```
+
+To read issues from dupFinder log files you need to import the core addin and the dupFinder support:
+
+```csharp
+#addin "Cake.Issues"
+#addin "Cake.Issues.DupFinder"
+```
+
+:::{.alert .alert-warning}
+Please note that you always should pin addins and tools to a specific version to make sure your builds are deterministic and
+won't break due to updates to one of the packages.
+
+See [pinning addin versions](https://cakebuild.net/docs/tutorials/pinning-cake-version#pinning-addin-version) for details.
+:::
+
+We need some global variables:
+
+```csharp
+var logPath = @"c:\build\dupfinder.xml";
+var repoRootPath = @"c:\repo";
+```
+
+The following task will run [JetBrains dupFinder] and write a log file:
+
+```csharp
+Task("Analyze-Project").Does(() =>
+{
+    // Run DupFinder.
+    var settings = new DupFinderSettings() {
+        OutputFile = logPath
+    };
+
+    DupFinder(repoRootPath.CombineWithFilePath("MySolution.sln"), settings);
+});
+```
+
+Finally you can define a task where you call the core addin with the desired issue provider.
+
+```csharp
+Task("Read-Issues")
+    .IsDependentOn("Analyze-Project")
+    .Does(() =>
+    {
+        // Read Issues.
+        var issues =
+            ReadIssues(
+                DupFinderIssuesFromFilePath(logPath),
+                repoRootPath);
+
+        Information("{0} issues are found.", issues.Count());
+    });
+```
+
+[JetBrains dupFinder]: https://www.jetbrains.com/help/resharper/dupFinder.html

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,32 @@
+---
+Order: 20
+Title: Features
+Description: Features of the Cake.Issues.DupFinder addin.
+---
+The [Cake.Issues.DupFinder addin] provides the following features:
+
+# Basic features
+
+* Reads code duplicates from [JetBrains dupFinder] log files.
+* For every duplicate fragment a separate issue is created.
+
+# Supported IIssue properties
+
+|                                                                    | Property                          | Remarks                          |
+|--------------------------------------------------------------------|-----------------------------------|----------------------------------|
+| <span class="glyphicon glyphicon-ok" style="color:green"></span>   | `IIssue.ProviderType`             |                                  |
+| <span class="glyphicon glyphicon-ok" style="color:green"></span>   | `IIssue.ProviderName`             |                                  |
+| <span class="glyphicon glyphicon-remove" style="color:red"></span> | `IIssue.ProjectName`              |                                  |
+| <span class="glyphicon glyphicon-remove" style="color:red"></span> | `IIssue.ProjectFileRelativePath`  |                                  |
+| <span class="glyphicon glyphicon-ok" style="color:green"></span>   | `IIssue.AffectedFileRelativePath` |                                  |
+| <span class="glyphicon glyphicon-ok" style="color:green"></span>   | `IIssue.Line`                     |                                  |
+| <span class="glyphicon glyphicon-ok" style="color:green"></span>   | `IIssue.MessageText`              |                                  |
+| <span class="glyphicon glyphicon-ok" style="color:green"></span>   | `IIssue.MessageHtml`              |                                  |
+| <span class="glyphicon glyphicon-ok" style="color:green"></span>   | `IIssue.MessageMarkdown`          |                                  |
+| <span class="glyphicon glyphicon-ok" style="color:green"></span>   | `IIssue.Priority`                 | Always [IssuePriority.Warning]   |
+| <span class="glyphicon glyphicon-ok" style="color:green"></span>   | `IIssue.PriorityName`             | Always `Warning`                 |
+| <span class="glyphicon glyphicon-ok" style="color:green"></span>   | `IIssue.Rule`                     | Always `dupFinder`               |
+| <span class="glyphicon glyphicon-remove" style="color:red"></span> | `IIssue.RuleUrl`                  |                                  |
+
+[JetBrains dupFinder]: https://www.jetbrains.com/help/resharper/dupFinder.html
+[Cake.Issues.DupFinder addin]: https://www.nuget.org/packages/Cake.Issues.DupFinder

--- a/docs/index.cshtml
+++ b/docs/index.cshtml
@@ -1,0 +1,12 @@
+---
+Title: dupFinder
+Description: Issue provider which allows you to read issues logged by JetBrains dupFinder.
+---
+<p>@Html.Raw(Model.String(DocsKeys.Description))</p>
+
+<p>
+    Support for reading issues reported by <a href="https://www.jetbrains.com/help/resharper/dupFinder.html" target="_blank">JetBrains dupFinder</a>
+    is implemented in the <a href="https://www.nuget.org/packages/Cake.Issues.DupFinder" target="_blank">Cake.Issues.DupFinder addin</a>.
+</p>
+
+@Html.Partial("_ChildPages")

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,0 +1,9 @@
+---
+Order: 10
+Title: Requirements
+Description: Requirements for the Cake.Issues.DupFinder addin.
+---
+The requirements for using the [Cake.Issues.DupFinder addin] are listed in the [release notes] for any specific version.
+
+[Cake.Issues.DupFinder addin]: https://www.nuget.org/packages/Cake.Issues.DupFinder
+[release notes]: release-notes


### PR DESCRIPTION
Adds documentation for the addin for inclusion in https://cakeissues.net/. 

Features need to be updated to match the actual implementation. Documentation in `requirements.md` assumes that requirements are listed in each release note entry on GitHub (which are imported into https://cakeissues.net/). 

@janniksam I'll it up to you to update the PR to matching your implementation