### PR TITLE
Feature/0.9.0 breaking changes

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -19,7 +19,11 @@ The [Cake.Issues.DupFinder addin] provides the following features:
 | <span class="glyphicon glyphicon-remove" style="color:red"></span> | `IIssue.ProjectName`              |                                  |
 | <span class="glyphicon glyphicon-remove" style="color:red"></span> | `IIssue.ProjectFileRelativePath`  |                                  |
 | <span class="glyphicon glyphicon-ok" style="color:green"></span>   | `IIssue.AffectedFileRelativePath` |                                  |
+| <span class="glyphicon glyphicon-ok" style="color:green"></span>   | `IIssue.Identifier`               |                                  |
 | <span class="glyphicon glyphicon-ok" style="color:green"></span>   | `IIssue.Line`                     |                                  |
+| <span class="glyphicon glyphicon-ok" style="color:green"></span>   | `IIssue.EndLine`                  |                                  |
+| <span class="glyphicon glyphicon-remove" style="color:red"></span> | `IIssue.Column`                   |                                  |
+| <span class="glyphicon glyphicon-remove" style="color:red"></span> | `IIssue.EndColumn`                |                                  |
 | <span class="glyphicon glyphicon-ok" style="color:green"></span>   | `IIssue.MessageText`              |                                  |
 | <span class="glyphicon glyphicon-ok" style="color:green"></span>   | `IIssue.MessageHtml`              |                                  |
 | <span class="glyphicon glyphicon-ok" style="color:green"></span>   | `IIssue.MessageMarkdown`          |                                  |

--- a/docs/features.md
+++ b/docs/features.md
@@ -16,10 +16,11 @@ The [Cake.Issues.DupFinder addin] provides the following features:
 |--------------------------------------------------------------------|-----------------------------------|----------------------------------|
 | <span class="glyphicon glyphicon-ok" style="color:green"></span>   | `IIssue.ProviderType`             |                                  |
 | <span class="glyphicon glyphicon-ok" style="color:green"></span>   | `IIssue.ProviderName`             |                                  |
+| <span class="glyphicon glyphicon-ok" style="color:green"></span>   | `IIssue.Run`                      | Can be set while reading issues  |
+| <span class="glyphicon glyphicon-ok" style="color:green"></span>   | `IIssue.Identifier`               |                                  |
 | <span class="glyphicon glyphicon-remove" style="color:red"></span> | `IIssue.ProjectName`              |                                  |
 | <span class="glyphicon glyphicon-remove" style="color:red"></span> | `IIssue.ProjectFileRelativePath`  |                                  |
 | <span class="glyphicon glyphicon-ok" style="color:green"></span>   | `IIssue.AffectedFileRelativePath` |                                  |
-| <span class="glyphicon glyphicon-ok" style="color:green"></span>   | `IIssue.Identifier`               |                                  |
 | <span class="glyphicon glyphicon-ok" style="color:green"></span>   | `IIssue.Line`                     |                                  |
 | <span class="glyphicon glyphicon-ok" style="color:green"></span>   | `IIssue.EndLine`                  |                                  |
 | <span class="glyphicon glyphicon-remove" style="color:red"></span> | `IIssue.Column`                   |                                  |

--- a/src/Cake.Issues.DupFinder.Tests/Cake.Issues.DupFinder.Tests.csproj
+++ b/src/Cake.Issues.DupFinder.Tests/Cake.Issues.DupFinder.Tests.csproj
@@ -17,8 +17,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Issues" Version="0.8.0" />
-    <PackageReference Include="Cake.Issues.Testing" Version="0.8.0" />
+    <PackageReference Include="Cake.Issues" Version="0.9.0-beta0002" />
+    <PackageReference Include="Cake.Issues.Testing" Version="0.9.0-beta0002" />
     <PackageReference Include="Cake.Testing" Version="0.33.0" />
     <PackageReference Include="Shouldly" Version="3.0.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/src/Cake.Issues.DupFinder.Tests/DupFinderIssuesProviderTests.cs
+++ b/src/Cake.Issues.DupFinder.Tests/DupFinderIssuesProviderTests.cs
@@ -68,11 +68,11 @@
                 issues.Count.ShouldBe(5);
                 issues.Count(i => 
                     i.FilePath() == "Src/Foo.cs" && 
-                    i.Line == 16).ShouldBe(1);
+                    i.Line == 16 && i.EndLine == 232).ShouldBe(1);
 
                 var issueToVerify = issues.Single(i =>
                     i.FilePath() == "Src/Foo.cs" &&
-                    i.Line == 16);
+                    i.Line == 16 && i.EndLine == 232);
 
                 IssueChecker.Check(
                     issueToVerify,
@@ -82,7 +82,7 @@
                             "DupFinder")
                         .WithMessageInMarkdownFormat(ExpectedIssueMarkdownMessage)
                         .WithMessageInHtmlFormat(ExpectedIssueHtmlMessage)
-                        .InFile(@"Src\Foo.cs", 16)
+                        .InFile(@"Src\Foo.cs", 16, 232, null, null)
                         .OfRule("dupFinder")
                         .WithPriority(IssuePriority.Warning)
                         .Create());

--- a/src/Cake.Issues.DupFinder.Tests/DupFinderIssuesProviderTests.cs
+++ b/src/Cake.Issues.DupFinder.Tests/DupFinderIssuesProviderTests.cs
@@ -38,6 +38,9 @@
 
         public sealed class TheReadIssuesMethod
         {
+            private const string ExpectedIssueIdentifier =
+                "Src\\Foo.cs-100-Src\\Bar.cs-Src\\FooBar.cs";
+ 
             private const string ExpectedIssueMessage =
                 "Possible duplicate detected (cost 100).\r\nThe following fragments were found that might be duplicates:\r\n" +
                 "\"Src\\Bar.cs\" (Line 17 to 233)\r\n" +
@@ -77,6 +80,7 @@
                 IssueChecker.Check(
                     issueToVerify,
                     IssueBuilder.NewIssue(
+                            ExpectedIssueIdentifier,
                             ExpectedIssueMessage,
                             "Cake.Issues.DupFinder.DupFinderIssuesProvider",
                             "DupFinder")

--- a/src/Cake.Issues.DupFinder/Cake.Issues.DupFinder.csproj
+++ b/src/Cake.Issues.DupFinder/Cake.Issues.DupFinder.csproj
@@ -22,7 +22,7 @@
   
   <ItemGroup>
     <PackageReference Include="Cake.Core" Version="0.33.0" />
-    <PackageReference Include="Cake.Issues" Version="0.8.0" />
+    <PackageReference Include="Cake.Issues" Version="0.9.0-beta0002" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Cake.Issues.DupFinder/DupFinderIssuesProvider.cs
+++ b/src/Cake.Issues.DupFinder/DupFinderIssuesProvider.cs
@@ -52,8 +52,7 @@
 
                 foreach (var fragment in fragments)
                 {
-                    // todo Add a good identifier implementation
-                    var identifier = GetSimpleMessage(cost, fragments, fragment);
+                    var identifier = GetIdentifier(cost, fragments, fragment);
                     var message = GetSimpleMessage(cost, fragments, fragment);
                     var htmlMessage = GetHtmlMessage(cost, fragments, fragment);
                     var mdMessage = GetMarkdownMessage(cost, fragments, fragment);
@@ -73,12 +72,19 @@
             return result;
         }
 
+        private static string GetIdentifier(int cost, IReadOnlyCollection<DuplicateFragment> fragments, DuplicateFragment fragment)
+        {
+            var otherFragments =
+                fragments.Where(f => !f.Equals(fragment)).OrderBy(f => f.FilePath).Select(p => p.FilePath);
+            return $"{fragment.FilePath}-{cost}-{string.Join("-", otherFragments)}";
+        }
+
         private static string GetHtmlMessage(int cost, IReadOnlyCollection<DuplicateFragment> fragments, DuplicateFragment fragment)
         {
             var builder = new StringBuilder();
             builder.Append($"Possible duplicate detected (cost {cost}).");
             builder.Append("<br/>The following fragments were found that might be duplicates:");
-            foreach (var possibleDuplicateFragment in fragments.Where(innerDuplicate => !innerDuplicate.Equals(fragment)))
+            foreach (var possibleDuplicateFragment in fragments.Where(f => !f.Equals(fragment)))
             {
                 builder.Append("<br/>");
                 builder.Append(
@@ -93,7 +99,7 @@
             var builder = new StringBuilder();
             builder.Append($"Possible duplicate detected (cost {cost}).\r\n");
             builder.Append("The following fragments were found that might be duplicates:");
-            foreach (var possibleDuplicateFragment in fragments.Where(innerDuplicate => !innerDuplicate.Equals(fragment)))
+            foreach (var possibleDuplicateFragment in fragments.Where(f => !f.Equals(fragment)))
             {
                 builder.Append("\r\n");
                 builder.Append(
@@ -108,7 +114,7 @@
             var builder = new StringBuilder();
             builder.Append($"Possible duplicate detected (cost {cost}).\r\n");
             builder.Append("The following fragments were found that might be duplicates:");
-            foreach (var possibleDuplicateFragment in fragments.Where(innerDuplicate => !innerDuplicate.Equals(fragment)))
+            foreach (var possibleDuplicateFragment in fragments.Where(f => !f.Equals(fragment)))
             {
                 builder.Append("\r\n");
                 builder.Append(

--- a/src/Cake.Issues.DupFinder/DupFinderIssuesProvider.cs
+++ b/src/Cake.Issues.DupFinder/DupFinderIssuesProvider.cs
@@ -52,16 +52,18 @@
 
                 foreach (var fragment in fragments)
                 {
+                    // todo Add a good identifier implementation
+                    var identifier = GetSimpleMessage(cost, fragments, fragment);
                     var message = GetSimpleMessage(cost, fragments, fragment);
                     var htmlMessage = GetHtmlMessage(cost, fragments, fragment);
                     var mdMessage = GetMarkdownMessage(cost, fragments, fragment);
 
                     result.Add(
                         IssueBuilder
-                            .NewIssue(message, this)
+                            .NewIssue(identifier, message, this)
                             .WithMessageInHtmlFormat(htmlMessage)
                             .WithMessageInMarkdownFormat(mdMessage)
-                            .InFile(fragment.FilePath, fragment.LineStart)
+                            .InFile(fragment.FilePath, fragment.LineStart, fragment.LineEnd, null, null)
                             .OfRule("dupFinder")
                             .WithPriority(IssuePriority.Warning)
                             .Create());


### PR DESCRIPTION
- Added support for the latest beta version features of Cake.Issues, including both `IIssue.EndLine` and the `IIssue.Identifier`.

For I now it needs Cake.Issues 0.9.0-beta002 or higher :)

Closing #26 and #28 