### PR TITLE
Consider end line for file link in message

### DIFF
--- a/src/Cake.Issues.DupFinder/DupFinderIssuesProvider.cs
+++ b/src/Cake.Issues.DupFinder/DupFinderIssuesProvider.cs
@@ -130,7 +130,7 @@
             var issue =
                 IssueBuilder
                     .NewIssue(fragment.FilePath, fragment.FilePath, this)
-                    .InFile(fragment.FilePath, fragment.LineStart)
+                    .InFile(fragment.FilePath, fragment.LineStart, fragment.LineEnd, null, null)
                     .Create();
 
             var resolvedPattern = this.Settings.FileLinkSettings.GetFileLink(issue);


### PR DESCRIPTION
Links in the message can link to the file range and not only start line